### PR TITLE
Misc. tweaks to improve JSON-to-Confluence formatting

### DIFF
--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -88,8 +88,8 @@ function Build-ArrayObject {
 	
 	if($null -ne $Action) {
 		$ActionFormatted = $Action -join " \\"
-		$ActionFormatted = $ActionFormatted.Replace("INSTALL","✔️INSTALL")
-		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","❌UNINSTALL")
+		$ActionFormatted = $ActionFormatted.Replace("INSTALL","📦INSTALL")
+		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","🗑️UNINSTALL")
 	}
 	
 	if($null -ne $Application.LocalizedDescription) {
@@ -106,14 +106,14 @@ function Build-ArrayObject {
 	
 	if($null -ne $AppDeployment.UpdateSupersedence) {
 		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️Yes Supersedence")
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌No Supersedence")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","👑✔️Enabled")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","👑❌Disabled")
 	}
 	
 	if($null -ne $ImplicitUninstall) {
 		$ImplicitUninstallFormatted = $ImplicitUninstall -join " \\"
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔️Implicit")
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌Not Implicit")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","🚮Implicit")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","🚯Not Implicit")
 	}
 
     $CollectionName = $Collection.Name

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -78,39 +78,39 @@ function Build-ArrayObject {
 	
 	# Certain fields may be arrays of values, if the collection has multiple deployments.
 	# Save a formatted version of those which are more readable after being JSON-ified:
-	if($IncludeMembershipRules.RuleName) {
+	if($null -ne $IncludeMembershipRules.RuleName) {
 		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules.RuleName -join " \\🔹")
 	}
 	
-	if($AppDeployment.ApplicationName) {
+	if($null -ne $AppDeployment.ApplicationName) {
 		$NameFormatted = "🔹" + ($AppDeployment.ApplicationName -join " \\🔹")
 	}
 	
-	if($Action) {
+	if($null -ne $Action) {
 		$ActionFormatted = $Action -join " \\"
 		$ActionFormatted = $ActionFormatted.Replace("INSTALL","✔️INSTALL")
 		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","❌UNINSTALL")
 	}
 	
-	if($Application.LocalizedDescription) {
+	if($null -ne $Application.LocalizedDescription) {
 		$CommentsFormatted = "🔹" + ($Application.LocalizedDescription -join " \\🔹")
 	}
 	
-	if($Purpose) {
+	if($null -ne $Purpose) {
 		$PurposeFormatted = $Purpose -join " \\"
 		$PurposeFormatted = $PurposeFormatted.Replace("AVAILABLE","💡AVAILABLE")
 		$PurposeFormatted = $PurposeFormatted.Replace("REQUIRED","🔒REQUIRED")
 	}
 	
-	if($AppDeployment.UpdateSupersedence) {
+	if($null -ne $AppDeployment.UpdateSupersedence) {
 		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️True")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔True")
 		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌False")
 	}
 	
-	if($ImplicitUninstall) {
+	if($null -ne $ImplicitUninstall) {
 		$ImplicitUninstallFormatted = $ImplicitUninstall -join " \\"
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","👍True")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔True")
 		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌False")
 	}
 

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -78,7 +78,7 @@ function Build-ArrayObject {
 	
 	# Certain fields may be arrays of values, if the collection has multiple deployments.
 	# Save a formatted version of those which are more readable after being JSON-ified:
-	if($null -ne $IncludeMembershipRules.RuleName) {
+	if($null -ne $IncludeMembershipRules) {
 		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules -join " \\🔹")
 	}
 	
@@ -287,8 +287,8 @@ function Get-CMOrgModelDeploymentRules{
 
                     if(
                         ($ISOnly) -and
-                        (-not ($ExcludeMembershipRules | Where-Object {$_.RuleName -like "UIUC-ENGR-IS*"}) ) -and
-                        (-not ($IncludeMembershipRules | Where-Object {$_.RuleName -like "UIUC-ENGR-IS*"}) )
+                        (-not ($ExcludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) ) -and
+                        (-not ($IncludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) )
                     ) {
                         # This weakly only filters by Exclude and Include membership rules, because we don't have easily identifiable conventions via Direct or Query-based membership rules
                         Write-Verbose "ISOnly flag was declared, but no Include or Exclude membership rules were found on $($Collection.Name) referencing `"UIUC-ENGR-IS*`" collections."

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -200,7 +200,7 @@ function Get-CMOrgModelDeploymentRules{
                 $DeployCollections = Get-CMDeviceCollection -Name $Test
             } else {
                 #$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
-				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*")
+				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
                 $DeployCollections = $DeployCollections | Sort-Object -Property Name
             }
 

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -200,7 +200,7 @@ function Get-CMOrgModelDeploymentRules{
                 $DeployCollections = Get-CMDeviceCollection -Name $Test
             } else {
                 #$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
-				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
+				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*")
                 $DeployCollections = $DeployCollections | Sort-Object -Property Name
             }
 

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -106,7 +106,7 @@ function Build-ArrayObject {
 	
 	if($null -ne $AppDeployment.UpdateSupersedence) {
 		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️Supersedes")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️Yes Supersedence")
 		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌No Supersedence")
 	}
 	

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -88,7 +88,7 @@ function Build-ArrayObject {
 	
 	if($null -ne $Action) {
 		$ActionFormatted = $Action -join " \\"
-		$ActionFormatted = $ActionFormatted.Replace("INSTALL","📦INSTALL")
+		$ActionFormatted = $ActionFormatted.Replace("INSTALL","💾INSTALL")
 		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","🗑️UNINSTALL")
 	}
 	

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -73,7 +73,18 @@ function Build-ArrayObject {
         $QueryMembershipRules,
         $Purpose
     )
+
+    $CollectionName = $Collection.Name
+    $Name = $AppDeployment.ApplicationName
+    $OverrideServiceWindows = $AppDeployment.OverrideServiceWindows
+    $RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows
+    $Supersedence = $AppDeployment.UpdateSupersedence
+    $Comments = $Application.LocalizedDescription
+	
+	### Lazy hack to account for us not being on GMT
+    $DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))
     
+	# Translate OfferFlags to determine whether Implicit Uninstall is enabled
 	$ImplicitUninstall = Resolve-ImplicitUninstall -ApplicationDeployment $AppDeployment
 	
 	# Certain fields may be arrays of values, if the collection has multiple deployments.
@@ -82,8 +93,8 @@ function Build-ArrayObject {
 		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules -join " \\🔹")
 	}
 	
-	if($null -ne $AppDeployment.ApplicationName) {
-		$NameFormatted = "🔹" + ($AppDeployment.ApplicationName -join " \\🔹")
+	if($null -ne $Name) {
+		$NameFormatted = "🔹" + ($Name -join " \\🔹")
 	}
 	
 	if($null -ne $Action) {
@@ -92,9 +103,9 @@ function Build-ArrayObject {
 		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","🗑️UNINSTALL")
 	}
 	
-	if($null -ne $Application.LocalizedDescription) {
-		if($Application.LocalizedDescription -ne "") {
-			$CommentsFormatted = "🔹" + ($Application.LocalizedDescription -join " \\🔹")
+	if($null -ne $Comments) {
+		if($Comments -ne "") {
+			$CommentsFormatted = "🔹" + ($Comments -join " \\🔹")
 		}
 	}
 	
@@ -104,8 +115,8 @@ function Build-ArrayObject {
 		$PurposeFormatted = $PurposeFormatted.Replace("REQUIRED","🔒REQUIRED")
 	}
 	
-	if($null -ne $AppDeployment.UpdateSupersedence) {
-		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
+	if($null -ne $Supersedence) {
+		$SupersedenceFormatted = $Supersedence -join " \\"
 		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","👑✔️Enabled")
 		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","👑❌Disabled")
 	}
@@ -115,15 +126,6 @@ function Build-ArrayObject {
 		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","🚮Implicit")
 		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","🚯Not Implicit")
 	}
-
-    $CollectionName = $Collection.Name
-    $Name = $AppDeployment.ApplicationName
-    ### Lazy hack to account for us not being on GMT
-    $DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))
-    $OverrideServiceWindows = $AppDeployment.OverrideServiceWindows
-    $RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows
-    $Supersedence = $AppDeployment.UpdateSupersedence
-    $Comments = $Application.LocalizedDescription
 
     Write-Verbose "Building the custom array for $CollectionName..."
     Write-Verbose "Name = $Name"

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -79,7 +79,7 @@ function Build-ArrayObject {
 	# Certain fields may be arrays of values, if the collection has multiple deployments.
 	# Save a formatted version of those which are more readable after being JSON-ified:
 	if($null -ne $IncludeMembershipRules.RuleName) {
-		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules.RuleName -join " \\🔹")
+		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules -join " \\🔹")
 	}
 	
 	if($null -ne $AppDeployment.ApplicationName) {
@@ -120,12 +120,12 @@ function Build-ArrayObject {
     Write-Verbose "Name = $($AppDeployment.ApplicationName)"
     Write-Verbose "DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))"
     Write-Verbose "Action = $Action"
-    Write-Verbose "DirectMembershipRules = $($DirectMembershipRules.RuleName)"
-    Write-Verbose "ExcludeMembershipRules = $($ExcludeMembershipRules.RuleName)"
-    Write-Verbose "IncludeMembershipRules = $($IncludeMembershipRules.RuleName)"
-    Write-Verbose "QueryMembershipRules = $($QueryMembershipRules.RuleName)"
     Write-Verbose "OverrideServiceWindows = $AppDeployment.OverrideServiceWindows"
     Write-Verbose "RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows"
+    Write-Verbose "DirectMembershipRules = $DirectMembershipRules"
+    Write-Verbose "ExcludeMembershipRules = $ExcludeMembershipRules"
+    Write-Verbose "IncludeMembershipRules = $IncludeMembershipRules"
+    Write-Verbose "QueryMembershipRules = $QueryMembershipRules"
     Write-Verbose "Purpose = $Purpose"
     Write-Verbose "Supersedence = $($AppDeployment.UpdateSupersedence)"
     Write-Verbose "ImplicitUninstall = $ImplicitUninstall"
@@ -140,11 +140,10 @@ function Build-ArrayObject {
         DeploymentStartTime             = $AppDeployment.StartTime.AddHours(5)
         Action                          = $Action
 		ActionFormatted                 = $ActionFormatted
-        DirectMembershipRules           = $DirectMembershipRules.RuleName
-        ExcludeMembershipRules          = $ExcludeMembershipRules.RuleName
-        IncludeMembershipRules          = $IncludeMembershipRules.RuleName
+        DirectMembershipRules           = $DirectMembershipRules
+        ExcludeMembershipRules          = $ExcludeMembershipRules
+        IncludeMembershipRules          = $IncludeMembershipRules
 		IncludeMembershipRulesFormatted = $IncludeMembershipRulesFormatted
-        QueryMembershipRules            = $QueryMembershipRules.RuleName
         OverrideServiceWindows          = $AppDeployment.OverrideServiceWindows
         RebootOutsideOfServiceWindows   = $AppDeployment.RebootOutsideOfServiceWindows
         Purpose                         = $Purpose
@@ -225,13 +224,13 @@ function Get-CMOrgModelDeploymentRules{
                 Write-Verbose "Initializing the Membership Rules array as empty"
                 $MembershipRules = $null
                 Write-Verbose "Getting Direct Membership Rules for $($Collection.Name)..."
-                $DirectMembershipRules = Get-CMDeviceCollectionDirectMembershipRule -CollectionName $Collection.Name
+                $DirectMembershipRules = (Get-CMDeviceCollectionDirectMembershipRule -CollectionName $Collection.Name).RuleName
                 Write-Verbose "Getting Exclude Membership Rules for $($Collection.Name)..."
-                $ExcludeMembershipRules = Get-CMDeviceCollectionExcludeMembershipRule -CollectionName $Collection.Name
+                $ExcludeMembershipRules = (Get-CMDeviceCollectionExcludeMembershipRule -CollectionName $Collection.Name).RuleName
                 Write-Verbose "Getting Include Membership Rules for $($Collection.Name)..."
-                $IncludeMembershipRules = Get-CMDeviceCollectionIncludeMembershipRule -CollectionName $Collection.Name
+                $IncludeMembershipRules = (Get-CMDeviceCollectionIncludeMembershipRule -CollectionName $Collection.Name).RuleName
                 Write-Verbose "Getting Query Membership Rules for $($Collection.Name)..."
-                $QueryMembershipRules = Get-CMDeviceCollectionQueryMembershipRule -CollectionName $Collection.Name
+                $QueryMembershipRules = (Get-CMDeviceCollectionQueryMembershipRule -CollectionName $Collection.Name).RuleName
                 
                 Write-Verbose "Getting the Application Deployment for $($Collection.Name)..."
                 $AppDeployment = Get-CMApplicationDeployment -Collection $Collection

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -199,9 +199,8 @@ function Get-CMOrgModelDeploymentRules{
             if($Test -and ($TestType -like "*string*")){
                 $DeployCollections = Get-CMDeviceCollection -Name $Test
             } else {
-                #$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
-				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*")
-                $DeployCollections = $DeployCollections | Sort-Object -Property Name
+                $DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
+				$DeployCollections = $DeployCollections | Sort-Object -Property Name
             }
 
             if($Test -and ($TestType -like "Int*")){

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -106,14 +106,14 @@ function Build-ArrayObject {
 	
 	if($null -ne $AppDeployment.UpdateSupersedence) {
 		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️True")
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌False")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️Supersedes")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌No Supersedence")
 	}
 	
 	if($null -ne $ImplicitUninstall) {
 		$ImplicitUninstallFormatted = $ImplicitUninstall -join " \\"
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔️True")
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌False")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔️Implicit")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌Not Implicit")
 	}
 
     $CollectionName = $Collection.Name

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -104,13 +104,13 @@ function Build-ArrayObject {
 	
 	if($null -ne $AppDeployment.UpdateSupersedence) {
 		$SupersedenceFormatted = $AppDeployment.UpdateSupersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔True")
+		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","✔️True")
 		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","❌False")
 	}
 	
 	if($null -ne $ImplicitUninstall) {
 		$ImplicitUninstallFormatted = $ImplicitUninstall -join " \\"
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔True")
+		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","✔️True")
 		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌False")
 	}
 

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -93,7 +93,9 @@ function Build-ArrayObject {
 	}
 	
 	if($null -ne $Application.LocalizedDescription) {
-		$CommentsFormatted = "🔹" + ($Application.LocalizedDescription -join " \\🔹")
+		if($Application.LocalizedDescription -ne "") {
+			$CommentsFormatted = "🔹" + ($Application.LocalizedDescription -join " \\🔹")
+		}
 	}
 	
 	if($null -ne $Purpose) {

--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -116,43 +116,59 @@ function Build-ArrayObject {
 		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","❌False")
 	}
 
-    Write-Verbose "Building the custom array for $($Collection.Name)..."
-    Write-Verbose "Name = $($AppDeployment.ApplicationName)"
-    Write-Verbose "DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))"
+    $CollectionName = $Collection.Name
+    $Name = $AppDeployment.ApplicationName
+    ### Lazy hack to account for us not being on GMT
+    $DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))
+    $OverrideServiceWindows = $AppDeployment.OverrideServiceWindows
+    $RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows
+    $Supersedence = $AppDeployment.UpdateSupersedence
+    $Comments = $Application.LocalizedDescription
+
+    Write-Verbose "Building the custom array for $CollectionName..."
+    Write-Verbose "Name = $Name"
+    Write-Verbose "NameFormatted = $NameFormatted"
+    Write-Verbose "DeploymentStartTime = $DeploymentStartTime"
     Write-Verbose "Action = $Action"
-    Write-Verbose "OverrideServiceWindows = $AppDeployment.OverrideServiceWindows"
-    Write-Verbose "RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows"
+    Write-Verbose "ActionFormatted = $ActionFormatted"
     Write-Verbose "DirectMembershipRules = $DirectMembershipRules"
     Write-Verbose "ExcludeMembershipRules = $ExcludeMembershipRules"
     Write-Verbose "IncludeMembershipRules = $IncludeMembershipRules"
+    Write-Verbose "IncludeMembershipRulesFormatted = $IncludeMembershipRulesFormatted"
     Write-Verbose "QueryMembershipRules = $QueryMembershipRules"
+    Write-Verbose "OverrideServiceWindows = $OverrideServiceWindows"
+    Write-Verbose "RebootOutsideOfServiceWindows = $RebootOutsideOfServiceWindows"
     Write-Verbose "Purpose = $Purpose"
-    Write-Verbose "Supersedence = $($AppDeployment.UpdateSupersedence)"
+    Write-Verbose "PurposeFormatted = $PurposeFormatted"
+    Write-Verbose "Supersedence = $Supersedence"
+    Write-Verbose "SupersedenceFormatted = $SupersedenceFormatted"
     Write-Verbose "ImplicitUninstall = $ImplicitUninstall"
-    Write-Verbose "Comments = $($Comments)"
+    Write-Verbose "ImplicitUninstallFormatted = $ImplicitUninstallFormatted"
+    Write-Verbose "Comments = $Comments"
+    Write-Verbose "CommentsFormatted = $CommentsFormatted"
 	
     ## Not sure how to handle Direct, Exclude, or Query rules yet. Will deal with them later
     [PSCustomObject]@{
-        CollectionName                  = $Collection.Name
-        Name                            = $AppDeployment.ApplicationName
+        CollectionName                  = $CollectionName
+        Name                            = $Name
 		NameFormatted                   = $NameFormatted
-        ### Lazy hack to account for us not being on GMT
-        DeploymentStartTime             = $AppDeployment.StartTime.AddHours(5)
+        DeploymentStartTime             = $DeploymentStartTime
         Action                          = $Action
 		ActionFormatted                 = $ActionFormatted
         DirectMembershipRules           = $DirectMembershipRules
         ExcludeMembershipRules          = $ExcludeMembershipRules
         IncludeMembershipRules          = $IncludeMembershipRules
 		IncludeMembershipRulesFormatted = $IncludeMembershipRulesFormatted
-        OverrideServiceWindows          = $AppDeployment.OverrideServiceWindows
-        RebootOutsideOfServiceWindows   = $AppDeployment.RebootOutsideOfServiceWindows
+        QueryMembershipRules            = $QueryMembershipRules
+        OverrideServiceWindows          = $OverrideServiceWindows
+        RebootOutsideOfServiceWindows   = $RebootOutsideOfServiceWindows
         Purpose                         = $Purpose
 		PurposeFormatted                = $PurposeFormatted
-        Supersedence                    = $AppDeployment.UpdateSupersedence
+        Supersedence                    = $Supersedence
 		SupersedenceFormatted           = $SupersedenceFormatted
         ImplicitUninstall               = $ImplicitUninstall
 		ImplicitUninstallFormatted      = $ImplicitUninstallFormatted
-        Comments                        = $Application.LocalizedDescription
+        Comments                        = $Comments
 		CommentsFormatted               = $CommentsFormatted
     }
 }


### PR DESCRIPTION
I played around with this for a while and was able to modify the output to greatly improve readability when the JSON is imported as a table in Confluence. I tried to make my changes as unintrusive as possible. They leave all of the original raw data untouched and create new additional properties (i.e. table columns) which are formatted versions of the columns we care about.

See this page for the results of a full run: https://uofi.atlassian.net/wiki/spaces/engritinstruction/pages/36177357/Instructional+Software+Deployment+Grid+mseng3+Test. The confluence JSON table macro on that page test page has some config tweaks compared to your usual page, such as optimized column widths and font size.

You're probably aware of this, but the progress bar seems to output a bunch of blank lines after the run is over. I ended up just not using it.

Also, it's probably worth noting that currently this code will never find any Uninstall deployments, as we have historically named those like `UIUC-ENGR-Uninstall <app name>` or `UIUC-ENGR-IS Uninstall <app name>`.

Lastly, it would probably be useful for this module to include deployment collections which have no deployments in the output. That will make it easy to identify missing deployments or deployment collections which should be deleted.

Changelog is below:
- Updated code which translates deployment's "action" (a.k.a. "DesiredConfigType") integer to account for collections with multiple deployments.
- Updated code which translates deployment's "purpose" (a.k.a. "OfferTypeID") integer to account for collections with multiple deployments.
  - Renamed "DeploymentType" variable and associated code to use the term "Purpose" instead, to avoid confusion with the MECM term "deployment type". "Purpose" is used to refer to "OfferType" by some official Microsoft sources.
- Updated code which determines whether a deployment has Implicit Uninstall to account for collections with multiple deployments.
- Removed superfluous comments handling. i.e. $Application.LocalizedDescription will already be an array of comments if $Application is an array of applications.
- Added code to store formatted versions of select properties such that those which would be vanilla arrays of values associated with multiple deployments are instead stored as a readable string including confluence line breaks and emojis as "bullets"/delimiters. Removed previous code which partially handled this by reducing duplicate values to a single value.