### PR TITLE
Several improvements and new features. See commit description.

### DIFF
--- a/Get-CMOrgModelDeploymentRules.psm1
+++ b/Get-CMOrgModelDeploymentRules.psm1
@@ -1,6 +1,7 @@
 $DEFAULT_PREFIX = "UIUC-ENGR-"
 $DEFAULT_SITE_CODE = "MP0"
 $DEFAULT_PROVIDER = "sccmcas.ad.uillinois.edu"
+$DEFAULT_COMMENT = "None"
 
 function Connect-ToMECM {
 	[CmdletBinding(SupportsShouldProcess)]
@@ -28,7 +29,7 @@ function Resolve-ImplicitUninstall {
 	# Adapted from https://www.alkanesolutions.co.uk/2022/09/20/use-powershell-to-calculate-bit-flags/?doing_wp_cron=1696459713.4683570861816406250000
 
 	param(
-		$ApplicationDeployment
+		$OfferFlags
 	)
 
 	[flags()] 
@@ -44,18 +45,100 @@ function Resolve-ImplicitUninstall {
 		IMPLICITUNINSTALL = 64
 	}
 	
-	$ApplicationDeployment | ForEach-Object {
-		[SMS_ApplicationAssignment_OfferFlags]$assignmentFlags = $_.OfferFlags
+	[SMS_ApplicationAssignment_OfferFlags]$flags = $OfferFlags
 
-		Write-Verbose "Checking if the app has implicit uninstall enabled"
-		if ($assignmentFlags.HasFlag([SMS_ApplicationAssignment_OfferFlags]::IMPLICITUNINSTALL)) {
-			Write-Verbose "Implicit uninstall was enabled"
-			return $true
-		}else{
-			Write-Verbose "Implicit uninstall was disabled"
-			return $false
-		}
+	Write-Verbose "Checking if the app has implicit uninstall enabled"
+	if ($flags.HasFlag([SMS_ApplicationAssignment_OfferFlags]::IMPLICITUNINSTALL)) {
+		Write-Verbose "Implicit uninstall was enabled"
+		return $true
+	}else{
+		Write-Verbose "Implicit uninstall was disabled"
+		return $false
 	}
+}
+
+function Translate-FeatureType($featureType) {
+	# https://learn.microsoft.com/en-us/mem/configmgr/develop/reference/apps/sms_deploymentsummary-server-wmi-class
+	$featureTypes = @(
+		[PSCustomObject]@{ Id = 1; Meaning = "Application" },
+		[PSCustomObject]@{ Id = 2; Meaning = "Program" },
+		[PSCustomObject]@{ Id = 3; Meaning = "MobileProgram" },
+		[PSCustomObject]@{ Id = 4; Meaning = "Script" },
+		[PSCustomObject]@{ Id = 5; Meaning = "SoftwareUpdate" },
+		[PSCustomObject]@{ Id = 6; Meaning = "Baseline" },
+		[PSCustomObject]@{ Id = 7; Meaning = "TaskSequence" },
+		[PSCustomObject]@{ Id = 8; Meaning = "ContentDistribution" },
+		[PSCustomObject]@{ Id = 9; Meaning = "DistributionPointGroup" },
+		[PSCustomObject]@{ Id = 10; Meaning = "DistributionPointHealth" },
+		[PSCustomObject]@{ Id = 11; Meaning = "ConfigurationPolicy" },
+		[PSCustomObject]@{ Id = 28; Meaning = "AbstractConfigurationItem" }
+	)
+	
+	$result = $featureTypes | Where { $_.Id -eq $featureType } | Select -ExpandProperty "Meaning"
+	if(-not $result) { $result = "UNKNOWN" }
+	
+	$result
+}
+
+function Translate-DeploymentIntent($deploymentIntent) {
+	# https://learn.microsoft.com/en-us/mem/configmgr/develop/reference/apps/sms_appdeploymentassetdetails-server-wmi-class
+	# Note: "DeploymentIntent" (or "intent") is also sometimes known as "purpose"
+	$deploymentIntents = @(
+		[PSCustomObject]@{ Id = 1; Meaning = "Required" },
+		[PSCustomObject]@{ Id = 2; Meaning = "Available" },
+		[PSCustomObject]@{ Id = 3; Meaning = "Simulate" }
+	)
+	
+	$result = $deploymentIntents | Where { $_.Id -eq $deploymentIntent } | Select -ExpandProperty "Meaning"
+	if(-not $result) { $result = "UNKNOWN" }
+	
+	$result
+}
+
+# OfferTypeID is the application-only version of the DeploymentIntent property, which is available on the more generic deployment object
+<#
+function Translate-OfferTypeID($offerTypeId) {
+	# https://learn.microsoft.com/en-us/mem/configmgr/develop/reference/apps/sms_applicationassignment-server-wmi-class
+	# Note: "offertype" is also sometimes known as "intent" or "purpose"
+	$offerTypeIds = @(
+		[PSCustomObject]@{ Id = 0; Meaning = "REQUIRED" },
+		[PSCustomObject]@{ Id = 2; Meaning = "AVAILABLE" }
+	)
+	
+	$result = $offerTypeIds | Where { $_.Id -eq $offerTypeId } | Select -ExpandProperty "Meaning"
+	if(-not $result) { $result = "UNKNOWN" }
+	
+	$result
+}
+#>
+
+function Translate-DesiredConfigType($desiredConfigType) {
+	# https://learn.microsoft.com/en-us/mem/configmgr/develop/reference/compliance/sms_ciassignmentbaseclass-server-wmi-class
+	# Note: "DesiredConfigType" (or "configtype") is also sometimes known as "action"
+	$desiredConfigTypes = @(
+		[PSCustomObject]@{ Id = 1; Meaning = "REQUIRED" }, # a.k.a. "INSTALL"
+		[PSCustomObject]@{ Id = 2; Meaning = "NOT_ALLOWED" } # a.k.a. "UNINSTALL"
+	)
+	
+	$result = $desiredConfigTypes | Where { $_.Id -eq $desiredConfigType } | Select -ExpandProperty "Meaning"
+	if(-not $result) { $result = "UNKNOWN" }
+	
+	$result
+}
+
+function Translate-Action($desiredConfigType) {
+	# Just translating DesiredConfigType again to make it more recognizable
+	$actions = @(
+		[PSCustomObject]@{ Id = 1; Meaning = "Install" },
+		[PSCustomObject]@{ Id = "REQUIRED"; Meaning = "Install" },
+		[PSCustomObject]@{ Id = 2; Meaning = "Uninstall" },
+		[PSCustomObject]@{ Id = "NOT_ALLOWED"; Meaning = "Uninstall" }
+	)
+	
+	$result = $actions | Where { $_.Id -eq $desiredConfigType } | Select -ExpandProperty "Meaning"
+	if(-not $result) { $result = "UNKNOWN" }
+	
+	$result
 }
 
 function Build-ArrayObject {
@@ -63,120 +146,156 @@ function Build-ArrayObject {
 	[CmdletBinding()]
 	param(
 		$Collection,
-		$Application,
-		$AppDeployment,
-		$Action,
-		$DirectMembershipRules,
-		$ExcludeMembershipRules,
 		$IncludeMembershipRules,
+		$ExcludeMembershipRules,
 		$QueryMembershipRules,
-		$Purpose
+		$DirectMembershipRules,
+		$Deployments
 	)
-
+	
 	$CollectionName = $Collection.Name
-	$Name = $AppDeployment.ApplicationName
-	$OverrideServiceWindows = $AppDeployment.OverrideServiceWindows
-	$RebootOutsideOfServiceWindows = $AppDeployment.RebootOutsideOfServiceWindows
-	$Supersedence = $AppDeployment.UpdateSupersedence
-	$Comments = $Application.LocalizedDescription
+	Write-Verbose "Building the custom array for $CollectionName..."
 	
-	### Lazy hack to account for us not being on GMT
-	$DeploymentStartTime = $($AppDeployment.StartTime.AddHours(5))
-	
-	# Translate OfferFlags to determine whether Implicit Uninstall is enabled
-	$ImplicitUninstall = Resolve-ImplicitUninstall -ApplicationDeployment $AppDeployment
+	$LimitingCollection = $Collection.LimitToCollectionName
+	$CollectionNameFormatted = $CollectionName
+	if($null -ne $LimitingCollection) {
+		$CollectionNameFormatted = "📂$($CollectionName)" + " \\ \\️🛡️$($LimitingCollection)"
+	}
 	
 	# Certain fields may be arrays of values, if the collection has multiple deployments.
 	# Save a formatted version of those which are more readable after being JSON-ified:
-	if($null -ne $IncludeMembershipRules) {
-		$IncludeMembershipRulesFormatted = "🔹" + ($IncludeMembershipRules -join " \\🔹")
-	}
-	
-	if($null -ne $ExcludeMembershipRules) {
-		$ExcludeMembershipRulesFormatted = "🔸" + ($ExcludeMembershipRules -join " \\🔸")
-	}
-	
-	if($null -ne $Name) {
-		$NameFormatted = "💠" + ($Name -join " \\💠")
-	}
-	
-	if($null -ne $Action) {
-		$ActionFormatted = $Action -join " \\"
-		$ActionFormatted = $ActionFormatted.Replace("INSTALL","💾INSTALL")
-		$ActionFormatted = $ActionFormatted.Replace("UNINSTALL","🗑️UNINSTALL")
-	}
-	
-	if($null -ne $Comments) {
-		if($Comments -ne "") {
-			$CommentsFormatted = "💠" + ($Comments -join " \\💠")
-		}
-	}
-	
-	if($null -ne $Purpose) {
-		$PurposeFormatted = $Purpose -join " \\"
-		$PurposeFormatted = $PurposeFormatted.Replace("AVAILABLE","💡AVAILABLE")
-		$PurposeFormatted = $PurposeFormatted.Replace("REQUIRED","🔒REQUIRED")
-	}
-	
-	if($null -ne $Supersedence) {
-		$SupersedenceFormatted = $Supersedence -join " \\"
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("True","👑✔️Enabled")
-		$SupersedenceFormatted = $SupersedenceFormatted.Replace("False","👑❌Disabled")
-	}
-	
-	if($null -ne $ImplicitUninstall) {
-		$ImplicitUninstallFormatted = $ImplicitUninstall -join " \\"
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("True","🚮Implicit")
-		$ImplicitUninstallFormatted = $ImplicitUninstallFormatted.Replace("False","🚯Not Implicit")
-	}
-
-	Write-Verbose "Building the custom array for $CollectionName..."
-	Write-Verbose "Name = $Name"
-	Write-Verbose "NameFormatted = $NameFormatted"
-	Write-Verbose "DeploymentStartTime = $DeploymentStartTime"
-	Write-Verbose "Action = $Action"
-	Write-Verbose "ActionFormatted = $ActionFormatted"
-	Write-Verbose "DirectMembershipRules = $DirectMembershipRules"
-	Write-Verbose "ExcludeMembershipRules = $ExcludeMembershipRules"
-	Write-Verbose "ExcludeMembershipRulesFormatted = $ExcludeMembershipRulesFormatted"
 	Write-Verbose "IncludeMembershipRules = $IncludeMembershipRules"
+	if($null -ne $IncludeMembershipRules) {
+		$bullet = "✔️&nbsp;"
+		$IncludeMembershipRulesFormatted = $bullet + ($IncludeMembershipRules -join " \\$bullet")
+	}
 	Write-Verbose "IncludeMembershipRulesFormatted = $IncludeMembershipRulesFormatted"
+	
+	Write-Verbose "ExcludeMembershipRules = $ExcludeMembershipRules"
+	if($null -ne $ExcludeMembershipRules) {
+		$bullet = "❌&nbsp;"
+		$ExcludeMembershipRulesFormatted = $bullet + ($ExcludeMembershipRules -join " \\$bullet")
+	}
+	Write-Verbose "ExcludeMembershipRulesFormatted = $ExcludeMembershipRulesFormatted"
+	
+	$IncludeAndExcludeMembershipRulesFormatted = $IncludeMembershipRulesFormatted + " \\" + $ExcludeMembershipRulesFormatted
+	# In case one or the other is null:
+	$IncludeAndExcludeMembershipRulesFormatted = $IncludeAndExcludeMembershipRulesFormatted.Trim(" \\")
+	Write-Verbose "IncludeAndExcludeMembershipRulesFormatted = $IncludeAndExcludeMembershipRulesFormatted"
+	
 	Write-Verbose "QueryMembershipRules = $QueryMembershipRules"
-	Write-Verbose "OverrideServiceWindows = $OverrideServiceWindows"
-	Write-Verbose "RebootOutsideOfServiceWindows = $RebootOutsideOfServiceWindows"
-	Write-Verbose "Purpose = $Purpose"
-	Write-Verbose "PurposeFormatted = $PurposeFormatted"
-	Write-Verbose "Supersedence = $Supersedence"
-	Write-Verbose "SupersedenceFormatted = $SupersedenceFormatted"
-	Write-Verbose "ImplicitUninstall = $ImplicitUninstall"
-	Write-Verbose "ImplicitUninstallFormatted = $ImplicitUninstallFormatted"
+	Write-Verbose "DirectMembershipRules = $DirectMembershipRules"
+	
+	$Contents = $Deployments._Content | Sort-Object "ApplicationName"
+	
+	$ContentNames = $Contents._NameWithType
+	Write-Verbose "ContentNames = $ContentNames"
+	if($null -ne $ContentNames) {
+		$contentNamesBulleted = $ContentNames | ForEach-Object {
+			$name = $_
+			$name = $name.Replace("Application;;","💠&nbsp;")
+			$name = $name.Replace("TaskSequence;;","📋&nbsp;")
+			$name = $name.Replace("None;;","❓&nbsp;")
+			# For unhandled content types
+			$name = $name -replace "^.*;;","🤷&nbsp;"
+			$name
+		}
+		$ContentNamesFormatted = $contentNamesBulleted -join " \\"
+	}
+	Write-Verbose "ContentNamesFormatted = $ContentNamesFormatted"
+	
+	$Comments = $Contents._Comment
 	Write-Verbose "Comments = $Comments"
+	if($null -ne $Comments) {
+		$commentsBulleted = $Comments | ForEach-Object {
+			$comment = $_
+			if($comment -eq "N/A") {
+				# Leave as is
+			}
+			elseif($comment -eq $DEFAULT_COMMENT) {
+				$comment = "💭&nbsp;$($comment)"
+			}
+			else {
+				$comment = "💬&nbsp;$($comment)"
+			}
+			$comment
+		}
+		$CommentsFormatted = $commentsBulleted -join " \\"
+	}
 	Write-Verbose "CommentsFormatted = $CommentsFormatted"
+
+	$Purposes = $Contents._Purpose
+	Write-Verbose "Purposes = $Purposes"
+	if($null -ne $Purposes) {
+		$PurposesFormatted = $Purposes -join " \\"
+		$PurposesFormatted = $PurposesFormatted.Replace("Available","💡&nbsp;Available")
+		$PurposesFormatted = $PurposesFormatted.Replace("Required","🔒&nbsp;Required")
+	}
+	Write-Verbose "PurposesFormatted = $PurposesFormatted"
+		
+	$Actions = $Contents._Action
+	Write-Verbose "Actions = $Actions"
+	if($null -ne $Actions) {
+		$ActionsFormatted = $Actions -join " \\"
+		$ActionsFormatted = $ActionsFormatted.Replace("Install","💾&nbsp;Install")
+		$ActionsFormatted = $ActionsFormatted.Replace("Uninstall","🗑&nbsp;Uninstall")
+	}
+	Write-Verbose "ActionsFormatted = $ActionsFormatted"
+	
+	$ImplicitUninstalls = $Contents._ImplicitUninstall
+	Write-Verbose "ImplicitUninstalls = $ImplicitUninstalls"
+	if($null -ne $ImplicitUninstalls) {
+		$ImplicitUninstallsFormatted = $ImplicitUninstalls -join " \\"
+		$ImplicitUninstallsFormatted = $ImplicitUninstallsFormatted.Replace("True","🚮&nbsp;Implicit")
+		$ImplicitUninstallsFormatted = $ImplicitUninstallsFormatted.Replace("False","🚯&nbsp;Not Implicit")
+	}
+	Write-Verbose "ImplicitUninstallsFormatted = $ImplicitUninstallsFormatted"
+	
+	$Supersedences = $Contents._Supersedence
+	Write-Verbose "Supersedences = $Supersedences"
+	if($null -ne $Supersedences) {
+		$SupersedencesFormatted = $Supersedences -join " \\"
+		$SupersedencesFormatted = $SupersedencesFormatted.Replace("True","👑&nbsp;✔️&nbsp;Enabled")
+		$SupersedencesFormatted = $SupersedencesFormatted.Replace("False","👑&nbsp;❌&nbsp;Disabled")
+	}
+	Write-Verbose "SupersedencesFormatted = $SupersedencesFormatted"
+	
+	$OverrideServiceWindowses = $Contents._OverrideServiceWindows
+	Write-Verbose "OverrideServiceWindowses = $OverrideServiceWindowses"
+	
+	$RebootOutsideOfServiceWindowses = $Contents._RebootOutsideOfServiceWindows
+	Write-Verbose "RebootOutsideOfServiceWindowses = $RebootOutsideOfServiceWindowses"
+	
+	$StartTimes = $Contents._StartTime
+	Write-Verbose "StartTimes = $StartTimes"
 	
 	## Not sure how to handle Direct, Exclude, or Query rules yet. Will deal with them later
 	[PSCustomObject]@{
 		CollectionName					= $CollectionName
-		Name							= $Name
-		NameFormatted					= $NameFormatted
-		DeploymentStartTime				= $DeploymentStartTime
-		Action							= $Action
-		ActionFormatted					= $ActionFormatted
-		DirectMembershipRules			= $DirectMembershipRules
-		ExcludeMembershipRules			= $ExcludeMembershipRules
-		ExcludeMembershipRulesFormatted	= $ExcludeMembershipRulesFormatted
+		LimitingCollection				= $LimitingCollection
+		CollectionNameF					= $CollectionNameFormatted
 		IncludeMembershipRules			= $IncludeMembershipRules
-		IncludeMembershipRulesFormatted	= $IncludeMembershipRulesFormatted
+		IncludeMembershipRulesF			= $IncludeMembershipRulesFormatted
+		ExcludeMembershipRules			= $ExcludeMembershipRules
+		ExcludeMembershipRulesF			= $ExcludeMembershipRulesFormatted
+		MembershipRulesF				= $IncludeAndExcludeMembershipRulesFormatted
 		QueryMembershipRules			= $QueryMembershipRules
-		OverrideServiceWindows			= $OverrideServiceWindows
-		RebootOutsideOfServiceWindows 	= $RebootOutsideOfServiceWindows
-		Purpose							= $Purpose
-		PurposeFormatted				= $PurposeFormatted
-		Supersedence					= $Supersedence
-		SupersedenceFormatted			= $SupersedenceFormatted
-		ImplicitUninstall				= $ImplicitUninstall
-		ImplicitUninstallFormatted		= $ImplicitUninstallFormatted
+		DirectMembershipRules			= $DirectMembershipRules
+		ContentNames					= $ContentNames
+		ContentNamesF					= $ContentNamesFormatted
 		Comments						= $Comments
-		CommentsFormatted				= $CommentsFormatted
+		CommentsF						= $CommentsFormatted
+		Purposes						= $Purposes
+		PurposesF						= $PurposesFormatted
+		Actions							= $Actions
+		ActionsF						= $ActionsFormatted
+		ImplicitUninstalls				= $ImplicitUninstalls
+		ImplicitUninstallsF				= $ImplicitUninstallsFormatted
+		Supersedences					= $Supersedences
+		SupersedencesF					= $SupersedencesFormatted
+		OverrideServiceWindowses		= $OverrideServiceWindowses
+		RebootOutsideOfServiceWindowses = $RebootOutsideOfServiceWindowses
+		StartTimes						= $StartTimes
 	}
 }
 
@@ -186,7 +305,12 @@ function Get-CMOrgModelDeploymentRules{
 	param(
 		[switch]$Json,
 		[switch]$ISOnly,
-		$Test,																		 # Shuffles then shrinks the array this runs on for faster testing
+		[switch]$IncludeCollectionsWithNoDeployments,
+		[string[]]$CollectionQueries = @("UIUC-ENGR-Deploy*","UIUC-ENGR-IS Deploy*","UIUC-ENGR-IS Uninstall*","UIUC-ENGR-IS Uninstall*"),
+		[switch]$Test,
+		[string[]]$TestCollectionQueries = @("UIUC-ENGR-IS Deploy A*","UIUC-ENGR-IS Uninstall A*"),
+		[switch]$RandomCollections,
+		[int]$RandomCollectionsNum = 10,
 		[switch]$NoProgressBar,
 		[string]$Prefix = $DEFAULT_PREFIX,
 		[string]$SiteCode=$DEFAULT_SITE_CODE,
@@ -218,15 +342,14 @@ function Get-CMOrgModelDeploymentRules{
 	process{
 		try{
 			Write-Host "Getting all collections... (note: this takes a while)"
-			if($Test -and ($TestType -like "*string*")){
-				$DeployCollections = Get-CMDeviceCollection -Name $Test
-			} else {
-				$DeployCollections = @(Get-CMDeviceCollection -Name "UIUC-ENGR-Deploy*") + @(Get-CMDeviceCollection -Name "UIUC-ENGR-IS Deploy*")
-				$DeployCollections = $DeployCollections | Sort-Object -Property Name
-			}
-
-			if($Test -and ($TestType -like "Int*")){
-				$DeployCollections = $DeployCollections | Get-Random -Count $Test
+			
+			if($Test) { $CollectionQueries = $TestCollectionQueries }
+			$DeployCollections = $CollectionQueries | ForEach-Object {
+				Get-CMDeviceCollection -Name $_
+			} | Sort-Object -Property "Name"
+			
+			if($RandomCollections) {
+				$DeployCollections = $DeployCollections | Get-Random -Count $RandomCollectionsNum
 			}
 
 			$TotalCollections = $DeployCollections.Count									# Using for progress bar
@@ -255,56 +378,158 @@ function Get-CMOrgModelDeploymentRules{
 				Write-Verbose "Getting Query Membership Rules for $($Collection.Name)..."
 				$QueryMembershipRules = (Get-CMDeviceCollectionQueryMembershipRule -CollectionName $Collection.Name).RuleName
 				
-				Write-Verbose "Getting the Application Deployment for $($Collection.Name)..."
-				$AppDeployment = Get-CMApplicationDeployment -Collection $Collection
-				Write-Verbose "Getting other Deployment info for $($Collection.Name)..."
-				$DeploySummary = Get-CMDeployment -CollectionName $Collection.Name
-				
+				# If -ISOnly was specified, ignore collections which do not have any membership rules which reference IS device collections
+				if(
+					($ISOnly) -and
+					(-not ($ExcludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) ) -and
+					(-not ($IncludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) )
+				) {
+					# This weakly only filters by Exclude and Include membership rules, because we don't have easily identifiable conventions via Direct or Query-based membership rules
+					Write-Verbose "ISOnly flag was declared, but no Include or Exclude membership rules were found on $($Collection.Name) referencing `"UIUC-ENGR-IS*`" collections."
+				} else {
+					
+					Write-Verbose "Getting the Deployments for $($Collection.Name)..."
+					$AllDeployments = Get-CMDeployment -CollectionName $Collection.Name
 
-				if($null -eq $AppDeployment){
-					if($NoProgressBar){
-						Write-Host "Skipping $($Collection.Name) because it has no App deployment"
+					if($null -eq $AllDeployments){
+						if($IncludeCollectionsWithNoDeployments) {
+							Write-Verbose "Collection has no deployments. Creating dummy deployment for output."
+							# Create a dummy deployment with dummy content so it ends up in the final array
+							# Populate all properties with dummy info so that rows with multiple deployments will have the same number of items in every cell
+							$FilteredDeployments = @{
+								ApplicationName = "No deployments!"
+								_Content = @{
+									_FeatureType = "None"
+									_NameWithType = "None;;No deployments!"
+									_Comment = "N/A"
+									_Purpose = "N/A"
+									_Action = "N/A"
+									_ImplicitUninstall = "N/A"
+									_Supersedence = "N/A"
+									_OverrideServiceWindows = "N/A"
+									_RebootOutsideOfServiceWindows = "N/A"
+									_StartTime = "N/A"
+								}
+							}
+						}
+						else {
+							Write-Verbose "Skipping $($Collection.Name) because it has no Deployments"
+						}
+					}else{
+						Write-Verbose "Getting Deployment info..."
+						$FilteredDeployments = $AllDeployments | ForEach-Object {
+							$deployment = $_
+							$deploymentId = $deployment.DeploymentId
+							$contentName = $deployment.ApplicationName
+							$purpose = $deployment.DeploymentIntent
+							$purposeTranslated = Translate-DeploymentIntent $purpose
+							$featureType = Translate-FeatureType $deployment.FeatureType
+							$nameWithType = "$($featureType);;$contentName"
+							
+							Write-Verbose "    Getting content info for `"$contentName`"..."
+							
+							if($featureType -eq "Application") {
+								Write-Verbose "Content is an application."
+								
+								# Get app info
+								$content = Get-CMApplication -Fast -Name $contentName
+								$comment = $content.LocalizedDescription
+								if(-not $comment) { $comment = $DEFAULT_COMMENT }
+								
+								# Get app deployment info
+								$contentDeployment = Get-CMApplicationDeployment -DeploymentId $deploymentId
+								$action = $contentDeployment.DesiredConfigType
+								$actionTranslated = Translate-Action $action
+								$supersedence = $contentDeployment.UpdateSupersedence
+								$implicitUninstall = Resolve-ImplicitUninstall -OfferFlags $contentDeployment.OfferFlags
+								$overrideServiceWindows = $contentDeployment.OverrideServiceWindows
+								$rebootOutsideOfServiceWindows = $contentDeployment.RebootOutsideOfServiceWindows
+								$startTime = $contentDeployment.StartTime
+								# Lazy hack to account for us not being on GMT
+								if($startTime) { $startTimeShifted = $startTime.AddHours(5) }
+							}
+							elseif($featureType -eq "TaskSequence") {
+								Write-Verbose "Content is a task sequence."
+								
+								# Get TS info
+								$content = Get-CMTaskSequence -Fast -Name $contentName
+								$comment = $content.LocalizedTaskSequenceDescription
+								if(-not $comment) { $comment = $DEFAULT_COMMENT }
+								
+								# Populate all properties with dummy info so that rows with multiple deployments will have the same number of items in every cell
+								$action = "N/A"
+								$actionTranslated = $action
+								$implicitUninstall = "N/A"
+								$supersedence = "N/A"
+								$overrideServiceWindows = "N/A"
+								$rebootOutsideOfServiceWindows = "N/A"
+								$startTime = "N/A"
+								
+								# Get TS deployment info
+								#$contentDeployment = Get-CMTaskSequenceDeployment -DeploymentId $deploymentId
+								# Everything we care about we already have in $deployment
+							}
+							else {
+								# Make a dummy content object so we have somewhere to attach the misc. info.
+								$content = [PSCustomObject]@{
+									Name = $contentName
+								}
+								
+								$action = "N/A"
+								$actionTranslated = $action
+								$implicitUninstall = "N/A"
+								$supersedence = "N/A"
+								$overrideServiceWindows = "N/A"
+								$rebootOutsideOfServiceWindows = "N/A"
+								$startTime = "N/A"
+							}
+							
+							if($content) {
+								if($content -eq "IGNORED") {
+									Write-Verbose "Skipping deployment because it's not an application nor a task sequence."
+								}
+								else {
+									$content | Add-Member -NotePropertyName "_FeatureType" -NotePropertyValue $featureType
+									$content | Add-Member -NotePropertyName "_NameWithType" -NotePropertyValue $nameWithType
+									$content | Add-Member -NotePropertyName "_Comment" -NotePropertyValue $comment
+									$content | Add-Member -NotePropertyName "_Purpose" -NotePropertyValue $purposeTranslated
+									$content | Add-Member -NotePropertyName "_Action" -NotePropertyValue $actionTranslated
+									$content | Add-Member -NotePropertyName "_ImplicitUninstall" -NotePropertyValue $implicitUninstall
+									$content | Add-Member -NotePropertyName "_Supersedence" -NotePropertyValue $supersedence
+									$content | Add-Member -NotePropertyName "_OverrideServiceWindows" -NotePropertyValue $overrideServiceWindows
+									$content | Add-Member -NotePropertyName "_RebootOutsideOfServiceWindows" -NotePropertyValue $rebootOutsideOfServiceWindows
+									$content | Add-Member -NotePropertyName "_StartTime" -NotePropertyValue $startTimeShifted
+									
+									Write-Verbose "Name = $contentName"
+									Write-Verbose "NameWithType = $nameWithType"
+									Write-Verbose "Comment = $comment"
+									Write-Verbose "Purpose = $purpose"
+									Write-Verbose "PurposeTranslated = $purposeTranslated"
+									Write-Verbose "Action = $action"
+									Write-Verbose "ActionTranslated = $actionTranslated"
+									Write-Verbose "ImplicitUninstall = $implicitUninstall"
+									Write-Verbose "Supersedence = $supersedence"
+									Write-Verbose "OverrideServiceWindows = $overrideServiceWindows"
+									Write-Verbose "RebootOutsideOfServiceWindows = $rebootOutsideOfServiceWindows"
+									Write-Verbose "StartTime = $startTime"
+									Write-Verbose "StartTimeShifted = $startTimeShifted"
+									
+									$deployment | Add-Member -NotePropertyName "_Content" -NotePropertyValue $content
+									$deployment
+								}
+							}
+							else {
+								Write-Verbose "Skipping deployment because its content could not be retrieved."
+							}
+						}
 					}
-				}else{
-					Write-Verbose "Getting Application info..."
-					Write-Verbose "Initializing the empty Applications array"
-					$Applications = New-Object System.Collections.ArrayList
-					foreach($AppD in $AppDeployment){
-						Write-Verbose "Getting Application info for $($AppD.ApplicationName)"
-						$Application = Get-CMApplication -Fast -Name $AppD.ApplicationName
-						Write-Verbose "Adding to the Applications array."
-						$Applications.Add($Application) | Out-Null
-					}
-
-					## Install or Uninstall
-					Write-Verbose "Determining whether this is Install or Uninstall"
-					$Action = switch($DeploySummary.DesiredConfigType){
-						1 { "INSTALL" }
-						2 { "UNINSTALL" }
-						Default { "UNKNOWN" }
-					}
-				
-					## Available or Required
-					Write-Verbose "Determining whether this is Required or Available"
-					$Purpose = switch($AppDeployment.OfferTypeID){
-						0 { "REQUIRED" }
-						2 { "AVAILABLE" }
-						Default { "UNKNOWN" }
-					}
-
-					if(
-						($ISOnly) -and
-						(-not ($ExcludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) ) -and
-						(-not ($IncludeMembershipRules | Where-Object {$_ -like "UIUC-ENGR-IS*"}) )
-					) {
-						# This weakly only filters by Exclude and Include membership rules, because we don't have easily identifiable conventions via Direct or Query-based membership rules
-						Write-Verbose "ISOnly flag was declared, but no Include or Exclude membership rules were found on $($Collection.Name) referencing `"UIUC-ENGR-IS*`" collections."
-					} else {
-						$MembershipRules = Build-ArrayObject -Collection $Collection -Application $Applications -AppDeployment $AppDeployment -Action $Action -DirectMembershipRules $DirectMembershipRules -ExcludeMembershipRules $ExcludeMembershipRules -IncludeMembershipRules $IncludeMembershipRules -QueryMembershipRules $QueryMembershipRules -Purpose $Purpose
-						Write-Verbose "Adding to the function output array."
-						Write-Verbose ($MembershipRules | Format-List | Out-String)
-						$output.Add($MembershipRules) | Out-Null
-					}
+					
+					# Using all of the gathered info, build an object suitable to represent one row of the table in which we want to view the data
+					$MembershipRules = Build-ArrayObject -Collection $Collection -IncludeMembershipRules $IncludeMembershipRules -ExcludeMembershipRules $ExcludeMembershipRules -QueryMembershipRules $QueryMembershipRules -DirectMembershipRules $DirectMembershipRules -Deployments $FilteredDeployments
+					Write-Verbose ($MembershipRules | Format-List | Out-String)
+					
+					Write-Verbose "Adding object to the output array."
+					$output.Add($MembershipRules) | Out-Null
 				}
 			}
 		} catch {

--- a/README.md
+++ b/README.md
@@ -23,13 +23,36 @@ Get-CMOrgModelDeploymentRules -ISOnly -Json
 ```
 
 # Parameters
+
 ### -Json
-Returns an output in the JSON format
+When specified, output is returned in JSON format.  
 
 ### -ISOnly
-Returns only results with Instructional device collections inside
+When specified, only deployment collections matching the given queries which also include Instructional Services device collections are returned.  
+Note: This simple filtering is just done on Include and Exclude rules, based on the naming convention of the included/excluded collections. This will not catch collections containing IS devices due to Direct Query-based membership rules.  
 
-Note: This simple filtering is just done on Inclusion and Exclusion rules on Device collections by name. This switch will not catch Direct adds or queries.
+### -IncludeCollectionsWithNoDeployments
+When specified, deployment collections which match the given queries are returned regardless of whether there are actually any deployments to the matching collections.  
+Useful to find collections intended to be deployment collections, but where the deployment is missing. Often this just means the app that previous deployed was retired and the collection was never removed.  
+By default collections which have no deployments are omitted from the output.  
 
 ### -NoProgressBar
-By default, this command uses a progress bar to show progress in processing membership rules. Specifying the `-NoProgressBar` switch will disable the progress bar and instead show each collection's name as it is being processed. Useful if you want to see all of the processed collections, but can be messy.
+By default, this command uses a progress bar to show progress in processing membership rules. Specifying the `-NoProgressBar` switch will disable the progress bar and instead show each collection's name as it is being processed. Useful if you want to see all of the processed collections, but can be messy.  
+
+### -CollectionQueries [string[]]
+String array of wildcard queries defining which collections should be polled.  
+Default is `@("UIUC-ENGR-Deploy*","UIUC-ENGR-IS Deploy*","UIUC-ENGR-IS Uninstall*","UIUC-ENGR-IS Uninstall*")`.  
+
+### -Test
+When specified the queries defined by `-TestCollectionQueries` are used, instead of those defined by `-CollectionQueries`.  
+
+### -TestCollectionQueries [string[]]
+Alternate set of deployment collection queries to be used for faster testing.  
+Default is `@("UIUC-ENGR-IS Deploy A*","UIUC-ENGR-IS Uninstall A*")`.  
+
+### -RandomCollections
+When specified, only a random set of deployment collections matching the given queries are processed, shortening the time to test, while still giving a hopefully representative, unique sample.  
+The number of collections in the randomly chosen set is defined by `-RandomCollectionsNum`.  
+
+### -RandomCollectionsNum [int]
+The number of collections to randomly select, when `-RandomCollections` is specified.  


### PR DESCRIPTION
Changes have been tested on https://uofi.atlassian.net/wiki/spaces/engritinstruction/pages/325648385/Instructional+Software+Deployment+Grid+Testing

I will migrate the necessary wiki page changes to the production page shortly.

Code changes:
- Major refactor to facilitate capturing deployments of TSes (and potentially other content types) in addition to apps.
- New switch allows capturing collections which do not have deployments.
- Now properly accounts for deployment collections for deployments of uninstalls (still based on the naming convention of New-CMOrgModelDeploymentCollection).
- Now outputs each collection's limiting collection. Used the same column as the collection name to avoid widening the table.
- Now populates all properties with default/dummy info for any info that is missing, so that rows with multiple deployments will have the same number of items in every cell
- Column names for formatted output data are now changed and shortened to improve table readability and to better reflect that they can contain multiple items.
- Several output formatting improvements and unicode emoji character changes for better table readability